### PR TITLE
Handle different json primitives

### DIFF
--- a/flat_json_widget/static/flat-json-widget/js/flat-json-widget.js
+++ b/flat_json_widget/static/flat-json-widget/js/flat-json-widget.js
@@ -100,8 +100,13 @@ var initJsonKeyValueWidget = function(fieldName, inlinePrefix) {
             var inputs = $(this).find('input'),
                 key = inputs.eq(0).val(),
                 value = inputs.eq(1).val();
+
+            if (typeof value != 'undefined') {
+                try { value = JSON.parse(value); } catch (e) {}
+            }
             newValue[key] = value;
         });
+
 
         // update textarea value
         $(rawTextarea).val(JSON.stringify(newValue, null, 4));


### PR DESCRIPTION
Fixes #8 

Fairly simple PR. Tested lightly.

Breaks backwards compatibility for values that match a json primitive. A few examples:
- When inputting `4`, what would be a `"4"` is now `4`
- When inputting `4.2`, what would be a `"4.2"` is now `4.2`
- When inputting `null`, what would be a `"null"` is now `null`
- When inputting `true`, what would be a `"true"` is now `true`
- When inputting `"quoted string"`, what would be a `"\"quoted_string\""` is now `"quoted_string"`
- When inputting `some other random string`, there's no change. The result will stay `"some other random string"` .

Personally, I would like to see it merged, since I'm using this package in a project I'm developing and I'm pretty happy with it!
Of course, I can use my fork in the meantime.
Let me know if there's anything else I can do.