### PR TITLE
[flat-json-widget] Preserve newline characters in input fields #19  Fixed an issue where newline characters (`\n`) in input fields were removed when saving via the HTML form. Updated the logic to ensure newline characters are preserved in both display and saved data.  Fixed #19

### DIFF
--- a/flat_json_widget/static/flat-json-widget/js/flat-json-widget.js
+++ b/flat_json_widget/static/flat-json-widget/js/flat-json-widget.js
@@ -99,7 +99,7 @@ var initJsonKeyValueWidget = function(fieldName, inlinePrefix) {
         rows.each(function() {
             var inputs = $(this).find('input'),
                 key = inputs.eq(0).val(),
-                value = inputs.eq(1).val()?.replace(/\\n/g , '\n');
+                value = inputs.eq(1).val() && inputs.eq(1).val().replace(/\\n/g , '\n');
             newValue[key] = value;
         });
 

--- a/flat_json_widget/static/flat-json-widget/js/flat-json-widget.js
+++ b/flat_json_widget/static/flat-json-widget/js/flat-json-widget.js
@@ -103,7 +103,7 @@ var initJsonKeyValueWidget = function(fieldName, inlinePrefix) {
             newValue[key] = value;
         });
 
-        // update textarea value
+        // update textarea value 
         $(rawTextarea).val(JSON.stringify(newValue, null, 4));
     };
 

--- a/flat_json_widget/static/flat-json-widget/js/flat-json-widget.js
+++ b/flat_json_widget/static/flat-json-widget/js/flat-json-widget.js
@@ -99,7 +99,7 @@ var initJsonKeyValueWidget = function(fieldName, inlinePrefix) {
         rows.each(function() {
             var inputs = $(this).find('input'),
                 key = inputs.eq(0).val(),
-                value = inputs.eq(1).val();
+                value = inputs.eq(1).val()?.replace(/\\n/g , '\n');
             newValue[key] = value;
         });
 

--- a/flat_json_widget/static/flat-json-widget/js/flat-json-widget.js
+++ b/flat_json_widget/static/flat-json-widget/js/flat-json-widget.js
@@ -103,7 +103,7 @@ var initJsonKeyValueWidget = function(fieldName, inlinePrefix) {
             newValue[key] = value;
         });
 
-        // update textarea value 
+        // update textarea value
         $(rawTextarea).val(JSON.stringify(newValue, null, 4));
     };
 

--- a/flat_json_widget/templates/flat_json_widget/flat_json_widget.html
+++ b/flat_json_widget/templates/flat_json_widget/flat_json_widget.html
@@ -36,7 +36,7 @@
                 </div>
             <% } %>
             <% for(key in data){ %>
-                <%= _.template(django.jQuery('.flat-json-row-template-inline').eq(0).html())({ 'key': key, 'value': data[key] }) %>
+                <%= _.template(django.jQuery('.flat-json-row-template-inline').eq(0).html())({ 'key': key, 'value': data[key].replace('\n' , '\\n') }) %>
             <% } %>
         </div>
 


### PR DESCRIPTION
**[flat-json-widget] Preserve newline characters in input fields (#19)**

### Description:
This PR fixes an issue where newline characters (`\n`) in input fields were being removed upon saving data through the HTML form. The logic has been updated to ensure that newline characters are preserved correctly in both the display and the saved data.

Fixes #19

### Checklist:
- [x] I have followed the OpenWISP contribution guidelines.
- [x] I have manually tested the changes proposed in this pull request.

### Testing:
- Verified that newline characters are retained in the input fields when editing and saving data via the HTML form.
