### PR TITLE
[setup] Updated the code for passing QA checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,4 @@ Pipfile
 tests/celerybeat*
 
 # virtual env
-/venv/
-
+.venv/

--- a/flat_json_widget/__init__.py
+++ b/flat_json_widget/__init__.py
@@ -1,18 +1,18 @@
-VERSION = (0, 4, 0, 'alpha')
+VERSION = (0, 4, 0, "alpha")
 __version__ = VERSION  # alias
 
 
 def get_version():  # pragma: no cover
-    version = '%s.%s' % (VERSION[0], VERSION[1])
+    version = "%s.%s" % (VERSION[0], VERSION[1])
     if VERSION[2]:
-        version = '%s.%s' % (version, VERSION[2])
-    if VERSION[3:] == ('alpha', 0):
-        version = '%s pre-alpha' % version
+        version = "%s.%s" % (version, VERSION[2])
+    if VERSION[3:] == ("alpha", 0):
+        version = "%s pre-alpha" % version
     else:
-        if VERSION[3] != 'final':
+        if VERSION[3] != "final":
             try:
                 rev = VERSION[4]
             except IndexError:
                 rev = 0
-            version = '%s%s%s' % (version, VERSION[3][0:1], rev)
+            version = "%s%s%s" % (version, VERSION[3][0:1], rev)
     return version

--- a/flat_json_widget/tests.py
+++ b/flat_json_widget/tests.py
@@ -6,19 +6,19 @@ from flat_json_widget.widgets import FlatJsonWidget
 class TestFlatJsonWidget(TestCase):
     def test_render(self):
         widget = FlatJsonWidget()
-        html = widget.render(name='content', value=None)
-        self.assertIn('flat-json-original-textarea', html)
-        self.assertIn('flat-json-textarea', html)
-        self.assertIn('icon-addlink.svg', html)
-        self.assertIn('icon-changelink.svg', html)
+        html = widget.render(name="content", value=None)
+        self.assertIn("flat-json-original-textarea", html)
+        self.assertIn("flat-json-textarea", html)
+        self.assertIn("icon-addlink.svg", html)
+        self.assertIn("icon-changelink.svg", html)
 
     def test_media(self):
         widget = FlatJsonWidget()
         html = widget.media.render()
         expected_list = [
-            '/static/flat-json-widget/css/flat-json-widget.css',
-            '/static/flat-json-widget/js/lib/underscore-umd-min.js',
-            '/static/flat-json-widget/js/flat-json-widget.js',
+            "/static/flat-json-widget/css/flat-json-widget.css",
+            "/static/flat-json-widget/js/lib/underscore-umd-min.js",
+            "/static/flat-json-widget/js/flat-json-widget.js",
         ]
         for expected in expected_list:
             self.assertIn(expected, html)

--- a/flat_json_widget/widgets.py
+++ b/flat_json_widget/widgets.py
@@ -9,18 +9,18 @@ class FlatJsonWidget(AdminTextareaWidget):
 
     @property
     def media(self):
-        internal_js = ['lib/underscore-umd-min.js', 'flat-json-widget.js']
-        js = ['admin/js/jquery.init.js'] + [
-            f'flat-json-widget/js/{path}' for path in internal_js
+        internal_js = ["lib/underscore-umd-min.js", "flat-json-widget.js"]
+        js = ["admin/js/jquery.init.js"] + [
+            f"flat-json-widget/js/{path}" for path in internal_js
         ]
-        css = {'all': ('flat-json-widget/css/flat-json-widget.css',)}
+        css = {"all": ("flat-json-widget/css/flat-json-widget.css",)}
         return forms.Media(js=js, css=css)
 
     def render(self, name, value, attrs=None, renderer=None):
         attrs = attrs or {}
         # it's called "original" because it will be replaced by a copy
-        attrs['class'] = 'flat-json-original-textarea'
+        attrs["class"] = "flat-json-original-textarea"
         html = super().render(name, value, attrs)
-        template = get_template('flat_json_widget/flat_json_widget.html')
-        html += template.render({'field_name': name})
+        template = get_template("flat_json_widget/flat_json_widget.html")
+        html += template.render({"field_name": name})
         return mark_safe(html)

--- a/runtests.py
+++ b/runtests.py
@@ -3,13 +3,13 @@
 import os
 import sys
 
-sys.path.insert(0, 'tests')
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+sys.path.insert(0, "tests")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from django.core.management import execute_from_command_line
 
     args = sys.argv
-    args.insert(1, 'test')
-    args.insert(2, 'flat_json_widget')
+    args.insert(1, "test")
+    args.insert(2, "flat_json_widget")
     execute_from_command_line(args)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,5 @@ force_grid_wrap=0
 
 [flake8]
 ignore = W605, W503, W504
+exclude = .venv/
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -4,49 +4,49 @@ from setuptools import find_packages, setup
 from flat_json_widget import get_version
 
 setup(
-    name='django-flat-json-widget',
+    name="django-flat-json-widget",
     version=get_version(),
-    license='BSD-3-Clause',
-    author='OpenWISP',
-    author_email='support@openwisp.io',
-    description='Django Flat JSON Key/Value Widget',
-    long_description=open('README.rst').read(),
-    url='https://github.com/openwisp/django-flat-json-widget',
-    download_url='https://github.com/openwisp/django-flat-json-widget/releases',
-    platforms=['Platform Independent'],
-    keywords=['django', 'json', 'key-value', 'widget'],
-    packages=find_packages(exclude=['tests*', 'docs*']),
+    license="BSD-3-Clause",
+    author="OpenWISP",
+    author_email="support@openwisp.io",
+    description="Django Flat JSON Key/Value Widget",
+    long_description=open("README.rst").read(),
+    url="https://github.com/openwisp/django-flat-json-widget",
+    download_url="https://github.com/openwisp/django-flat-json-widget/releases",
+    platforms=["Platform Independent"],
+    keywords=["django", "json", "key-value", "widget"],
+    packages=find_packages(exclude=["tests*", "docs*"]),
     include_package_data=True,
     zip_safe=False,
-    python_requires='>=3.9',
+    python_requires=">=3.9",
     install_requires=[
-        'django>=4.2,<5.3',
+        "django>=4.2,<5.3",
     ],
     extras_require={
-        'test': [
+        "test": [
             (
-                'openwisp-utils[qa]'
-                ' @ https://github.com/openwisp/openwisp-utils/tarball/1.2'
+                "openwisp-utils[qa]"
+                " @ https://github.com/openwisp/openwisp-utils/tarball/1.2"
             ),
-            'django-extensions>=3.2,<4.2',
+            "django-extensions>=3.2,<4.2",
         ]
     },
     classifiers=[
-        'Development Status :: 5 - Production/Stable ',
-        'Environment :: Web Environment',
-        'Topic :: Internet :: WWW/HTTP',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Framework :: Django',
-        'Framework :: Django :: 4.2',
-        'Framework :: Django :: 5.1',
-        'Framework :: Django :: 5.2',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
+        "Development Status :: 5 - Production/Stable ",
+        "Environment :: Web Environment",
+        "Topic :: Internet :: WWW/HTTP",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Framework :: Django",
+        "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.1",
+        "Framework :: Django :: 5.2",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/tests/manage.py
+++ b/tests/manage.py
@@ -2,8 +2,8 @@
 import os
 import sys
 
-if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
     from django.core.management import execute_from_command_line
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,92 +3,92 @@ import sys
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DEBUG = True
-TESTING = sys.argv[1:2] == ['test']
-SHELL = 'shell' in sys.argv or 'shell_plus' in sys.argv
+TESTING = sys.argv[1:2] == ["test"]
+SHELL = "shell" in sys.argv or "shell_plus" in sys.argv
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 DATABASES = {
-    'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': 'flat-json-widget.db'}
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "flat-json-widget.db"}
 }
 
-SECRET_KEY = 'fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w'
+SECRET_KEY = "fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w"
 
 INSTALLED_APPS = [
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'django_extensions',
-    'django.contrib.admin',
-    'flat_json_widget',
-    'test_app'
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django_extensions",
+    "django.contrib.admin",
+    "flat_json_widget",
+    "test_app",
     # 'debug_toolbar',
 ]
 
 STATICFILES_FINDERS = [
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-if 'debug_toolbar' in INSTALLED_APPS:
-    MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
-    INTERNAL_IPS = ['127.0.0.1']
+if "debug_toolbar" in INSTALLED_APPS:
+    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+    INTERNAL_IPS = ["127.0.0.1"]
 
-ROOT_URLCONF = 'urls'
+ROOT_URLCONF = "urls"
 
-TIME_ZONE = 'Europe/Rome'
-LANGUAGE_CODE = 'en-gb'
+TIME_ZONE = "Europe/Rome"
+LANGUAGE_CODE = "en-gb"
 USE_TZ = True
 USE_I18N = False
 USE_L10N = False
-STATIC_URL = '/static/'
-MEDIA_URL = '/media/'
-MEDIA_ROOT = f'{os.path.dirname(BASE_DIR)}/media/'
+STATIC_URL = "/static/"
+MEDIA_URL = "/media/"
+MEDIA_ROOT = f"{os.path.dirname(BASE_DIR)}/media/"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'OPTIONS': {
-            'loaders': [
-                'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader',
-                'openwisp_utils.loaders.DependencyLoader',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {
+            "loaders": [
+                "django.template.loaders.filesystem.Loader",
+                "django.template.loaders.app_directories.Loader",
+                "openwisp_utils.loaders.DependencyLoader",
             ],
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     }
 ]
 
-LOGIN_REDIRECT_URL = 'admin:index'
+LOGIN_REDIRECT_URL = "admin:index"
 
 # during development only
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 LOGGING = {
-    'version': 1,
-    'filters': {'require_debug_true': {'()': 'django.utils.log.RequireDebugTrue'}},
-    'handlers': {
-        'console': {
-            'level': 'DEBUG',
-            'filters': ['require_debug_true'],
-            'class': 'logging.StreamHandler',
+    "version": 1,
+    "filters": {"require_debug_true": {"()": "django.utils.log.RequireDebugTrue"}},
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "filters": ["require_debug_true"],
+            "class": "logging.StreamHandler",
         }
     },
 }
@@ -96,23 +96,23 @@ LOGGING = {
 if not TESTING and SHELL:
     LOGGING.update(
         {
-            'loggers': {
-                '': {
+            "loggers": {
+                "": {
                     # this sets root level logger to log debug and higher level
                     # logs to console. All other loggers inherit settings from
                     # root level logger.
-                    'handlers': ['console'],
-                    'level': 'DEBUG',
-                    'propagate': False,
+                    "handlers": ["console"],
+                    "level": "DEBUG",
+                    "propagate": False,
                 },
-                'django.db': {
-                    'level': 'DEBUG',
-                    'handlers': ['console'],
-                    'propagate': False,
+                "django.db": {
+                    "level": "DEBUG",
+                    "handlers": ["console"],
+                    "propagate": False,
                 },
             }
         }
     )
 
-TEST_RUNNER = 'openwisp_utils.tests.TimeLoggingTestRunner'
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+TEST_RUNNER = "openwisp_utils.tests.TimeLoggingTestRunner"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/tests/test_app/admin.py
+++ b/tests/test_app/admin.py
@@ -8,10 +8,10 @@ from .models import JsonDocument
 
 class JsonDocumentForm(forms.ModelForm):
     class Meta:
-        widgets = {'content': FlatJsonWidget}
+        widgets = {"content": FlatJsonWidget}
 
 
 @admin.register(JsonDocument)
 class JsonDocumentAdmin(admin.ModelAdmin):
-    list_display = ['name']
+    list_display = ["name"]
     form = JsonDocumentForm

--- a/tests/test_app/migrations/0001_initial.py
+++ b/tests/test_app/migrations/0001_initial.py
@@ -10,19 +10,19 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='JsonDocument',
+            name="JsonDocument",
             fields=[
                 (
-                    'id',
+                    "id",
                     models.AutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,
-                        verbose_name='ID',
+                        verbose_name="ID",
                     ),
                 ),
-                ('name', models.CharField(max_length=64, unique=True)),
-                ('content', models.JSONField()),
+                ("name", models.CharField(max_length=64, unique=True)),
+                ("content", models.JSONField()),
             ],
         ),
     ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -5,13 +5,13 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path("admin/", admin.site.urls),
 ]
 
 urlpatterns += staticfiles_urlpatterns()
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
-if settings.DEBUG and 'debug_toolbar' in settings.INSTALLED_APPS:
+if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:
     import debug_toolbar
 
-    urlpatterns += [path('^__debug__/', include(debug_toolbar.urls))]
+    urlpatterns += [path("^__debug__/", include(debug_toolbar.urls))]


### PR DESCRIPTION
While setting up the project locally, I noticed that QA checks were failing due to formatting inconsistencies and virtual environment files being included in linting and formatting.

To fix this:
- Ran `openwisp-qa-format` to apply consistent formatting across Python and frontend code.
- Changed `/venv/` to `.venv/` in `.gitignore` to correctly ignore the local virtual environment.
- Updated `setup.cfg` to exclude `.venv` from Flake8 checks.
- Added `.venv` to `.prettierignore` to prevent Prettier from formatting unnecessary files.

These changes ensure that QA checks pass during development and that only relevant files are included in the linting and formatting processes.