### PR TITLE
[qa] Added frontend tests #02

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 ---
+
 name: Django Flat JSON Widget CI Build
 
 on:
@@ -10,6 +11,7 @@ on:
       - master
 
 jobs:
+
   build:
     name: Python==${{ matrix.python-version }} | ${{ matrix.django-version }}
     runs-on: ubuntu-24.04
@@ -38,70 +40,70 @@ jobs:
             django-version: django~=4.2.0
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Cache APT packages
-        uses: actions/cache@v4
-        with:
-          path: /var/cache/apt/archives
-          key: apt-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
-          restore-keys: |
-            apt-${{ runner.os }}-
+    - name: Cache APT packages
+      uses: actions/cache@v4
+      with:
+        path: /var/cache/apt/archives
+        key: apt-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+        restore-keys: |
+          apt-${{ runner.os }}-
 
-      - name: Disable man page auto-update
-        run: |
-          echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
-          sudo dpkg-reconfigure man-db
+    - name: Disable man page auto-update
+      run: |
+        echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
+        sudo dpkg-reconfigure man-db
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: |
-            setup.py
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.py
 
-      - name: Install Dependencies
-        id: deps
-        run: |
-          pip install -U pip wheel setuptools
-          pip install -U -e .[test]
-          pip install ${{ matrix.django-version }}
-          sudo npm install -g prettier
+    - name: Install Dependencies
+      id: deps
+      run: |
+        pip install -U pip wheel setuptools
+        pip install -U -e .[test]
+        pip install ${{ matrix.django-version }}
+        sudo npm install -g prettier
 
-      - name: QA checks
-        run: |
-          ./run-qa-checks
+    - name: QA checks
+      run: |
+        ./run-qa-checks
 
-      - name: Tests
-        if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
-        run: |
-          coverage run runtests.py
-          coverage xml
-        env:
-          SELENIUM_HEADLESS: 1
-          GECKO_LOG: 1
+    - name: Tests
+      if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
+      run: |
+        coverage run runtests.py
+        coverage xml
+      env:
+        SELENIUM_HEADLESS: 1
+        GECKO_LOG: 1
 
-      - name: Show gecko web driver log on failures
-        if: ${{ failure() }}
-        run: cat geckodriver.log
+    - name: Show gecko web driver log on failures
+      if: ${{ failure() }}
+      run: cat geckodriver.log
 
-      - name: Upload Coverage
-        if: ${{ success() }}
-        uses: coverallsapp/github-action@v2
-        with:
-          parallel: true
-          format: cobertura
-          flag-name: python-${{ matrix.env.env }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload Coverage
+      if: ${{ success() }}
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel: true
+        format: cobertura
+        flag-name: python-${{ matrix.env.env }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
   coveralls:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
-        with:
-          parallel-finished: true
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 ---
-
 name: Django Flat JSON Widget CI Build
 
 on:
@@ -11,7 +10,6 @@ on:
       - master
 
 jobs:
-
   build:
     name: Python==${{ matrix.python-version }} | ${{ matrix.django-version }}
     runs-on: ubuntu-24.04
@@ -40,63 +38,70 @@ jobs:
             django-version: django~=4.2.0
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Cache APT packages
-      uses: actions/cache@v4
-      with:
-        path: /var/cache/apt/archives
-        key: apt-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
-        restore-keys: |
-          apt-${{ runner.os }}-
+      - name: Cache APT packages
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/apt/archives
+          key: apt-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: |
+            apt-${{ runner.os }}-
 
-    - name: Disable man page auto-update
-      run: |
-        echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
-        sudo dpkg-reconfigure man-db
+      - name: Disable man page auto-update
+        run: |
+          echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
+          sudo dpkg-reconfigure man-db
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: |
-          setup.py
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            setup.py
 
-    - name: Install Dependencies
-      id: deps
-      run: |
-        pip install -U pip wheel setuptools
-        pip install -U -e .[test]
-        pip install ${{ matrix.django-version }}
-        sudo npm install -g prettier
+      - name: Install Dependencies
+        id: deps
+        run: |
+          pip install -U pip wheel setuptools
+          pip install -U -e .[test]
+          pip install ${{ matrix.django-version }}
+          sudo npm install -g prettier
 
-    - name: QA checks
-      run: |
-        ./run-qa-checks
+      - name: QA checks
+        run: |
+          ./run-qa-checks
 
-    - name: Tests
-      if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
-      run: |
-        coverage run runtests.py
-        coverage xml
+      - name: Tests
+        if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
+        run: |
+          coverage run runtests.py
+          coverage xml
+        env:
+          SELENIUM_HEADLESS: 1
+          GECKO_LOG: 1
 
-    - name: Upload Coverage
-      if: ${{ success() }}
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel: true
-        format: cobertura
-        flag-name: python-${{ matrix.env.env }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Show gecko web driver log on failures
+        if: ${{ failure() }}
+        run: cat geckodriver.log
+
+      - name: Upload Coverage
+        if: ${{ success() }}
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel: true
+          format: cobertura
+          flag-name: python-${{ matrix.env.env }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   coveralls:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel-finished: true
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/runtests.py
+++ b/runtests.py
@@ -12,4 +12,5 @@ if __name__ == "__main__":
     args = sys.argv
     args.insert(1, "test")
     args.insert(2, "flat_json_widget")
+    args.insert(3, "tests")
     execute_from_command_line(args)

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,10 @@ setup(
     extras_require={
         "test": [
             (
-                "openwisp-utils[qa]"
+                "openwisp-utils[qa, selenium]"
                 " @ https://github.com/openwisp/openwisp-utils/tarball/1.2"
             ),
             "django-extensions>=3.2,<4.2",
-            "selenium>=4.0.0,<5.0.0",
         ]
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     extras_require={
         "test": [
             (
-                "openwisp-utils[qa, selenium]"
+                "openwisp-utils[qa,selenium]"
                 " @ https://github.com/openwisp/openwisp-utils/tarball/1.2"
             ),
             "django-extensions>=3.2,<4.2",

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
                 " @ https://github.com/openwisp/openwisp-utils/tarball/1.2"
             ),
             "django-extensions>=3.2,<4.2",
+            "selenium>=4.0.0,<5.0.0",
         ]
     },
     classifiers=[

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from django.contrib.auth import get_user_model
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.urls import reverse
@@ -79,8 +81,7 @@ class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
         self.wait_for_presence(By.CLASS_NAME, "flat-json-remove-row")
         remove_buttons = self.find_elements(By.CLASS_NAME, REMOVE_ROW_BUTTON)
         second_row_remove_btn = remove_buttons[1]
-        from time import sleep
-        sleep(0.5)
+        sleep(0.25)  # workaround for random CI failures
         self.scroll_and_click(second_row_remove_btn)
         rows = self.find_elements(By.CSS_SELECTOR, ".flat-json-rows .form-row")
         self.assertEqual(

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -1,0 +1,150 @@
+from django.contrib.auth import get_user_model
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from openwisp_utils.tests.selenium import SeleniumTestMixin
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+
+from .models import JsonDocument
+
+ADD_ROW_BUTTON = "flat-json-add-row"
+REMOVE_ROW_BUTTON = "flat-json-remove-row"
+SAVE_BUTTON = ".submit-row .default"
+TOGGLE_TEXTAREA_BUTTON = "flat-json-toggle-textarea"
+TEST_JSON_CONTENT = {
+    "first_key": "first_val",
+    "second_key": "second_val",
+    "third_key": "third_val",
+}
+
+
+class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
+    """Functional tests for the flat JSON widget in Django admin using Selenium"""
+
+    def _create_admin(self, username, password):
+        User = get_user_model()
+        return User.objects.create_superuser(
+            username,
+            "admin@admin.com",
+            password,
+        )
+
+    # Overriding open() and _wait_until_page_ready() so that #main
+    # is used instead of #main-content as CSS selector.
+    def open(self, url, html_container="#main", driver=None, timeout=5):
+        driver = driver or self.web_driver
+        driver.get(f"{self.live_server_url}{url}")
+        self._wait_until_page_ready(driver=driver, html_container=html_container)
+
+    def _wait_until_page_ready(self, html_container="#main", timeout=5, driver=None):
+        driver = driver or self.web_driver
+        WebDriverWait(driver, timeout).until(
+            lambda d: d.execute_script("return document.readyState") == "complete"
+        )
+        self.wait_for_visibility(By.CSS_SELECTOR, html_container, timeout, driver)
+
+    def test_add_row(self):
+        """This test checks whether the add-row button works properly."""
+
+        self.login()
+        self.open("/admin/test_app/jsondocument/add")
+        self.find_element(By.CLASS_NAME, ADD_ROW_BUTTON).click()
+        self.wait_for_visibility(By.CSS_SELECTOR, ".flat-json-rows .form-row")
+        rows = self.find_elements(By.CSS_SELECTOR, ".flat-json-rows .form-row")
+        self.assertEqual(len(rows), 1)
+        self.find_element(By.CSS_SELECTOR, ".field-name input").send_keys("TestJson")
+        rows[0].find_element(By.CLASS_NAME, "flat-json-key").send_keys("test_key")
+        rows[0].find_element(By.CLASS_NAME, "flat-json-value").send_keys("test_value")
+        self.find_element(By.CSS_SELECTOR, SAVE_BUTTON).click()
+        self.wait_for_presence(By.CSS_SELECTOR, ".messagelist .success")
+        json = JsonDocument.objects.first()
+        self.assertEqual(len(json.content), 1, "Expected 1 row")
+        self.assertEqual(json.name, "TestJson")
+        self.assertEqual(
+            json.content,
+            {"test_key": "test_value"},
+        )
+
+    def test_remove_row(self):
+        """This test checks whether the remove-row button removes the desired row"""
+
+        json_doc = JsonDocument.objects.create(
+            name="test_json", content=TEST_JSON_CONTENT
+        )
+        self.login()
+        self.open(f"/admin/test_app/jsondocument/{json_doc.pk}/change")
+        self.wait_for_visibility(By.CLASS_NAME, "flat-json-remove-row")
+        remove_buttons = self.find_elements(By.CLASS_NAME, REMOVE_ROW_BUTTON)
+        second_row_remove_btn = remove_buttons[1]
+        second_row_remove_btn.click()
+        rows = self.find_elements(By.CSS_SELECTOR, ".flat-json-rows .form-row")
+        self.assertEqual(
+            len(rows), 2, "Error in display: Expected 2 rows after removing one"
+        )
+        self.find_element(By.CSS_SELECTOR, SAVE_BUTTON).click()
+        self.wait_for_presence(By.CSS_SELECTOR, ".messagelist .success")
+        json = JsonDocument.objects.first().content
+        self.assertEqual(
+            len(json), 2, "Error in saving: Expected 2 rows after removing one."
+        )
+        self.assertEqual(
+            json,
+            {
+                "first_key": "first_val",
+                "third_key": "third_val",
+            },
+        )
+
+    def test_toggle_textarea(self):
+        """Tests whether the toggle button toggles between widgets and textarea"""
+
+        self.login()
+        self.open("/admin/test_app/jsondocument/add/")
+        toggle_btn = self.find_element(By.CLASS_NAME, TOGGLE_TEXTAREA_BUTTON)
+        toggle_btn.click()
+        self.wait_for_invisibility(By.CLASS_NAME, "flat-json-rows")
+        self.wait_for_invisibility(By.CLASS_NAME, ADD_ROW_BUTTON)
+        self.wait_for_visibility(By.CLASS_NAME, "flat-json-textarea")
+
+    def test_edit_json_from_textarea(self):
+        """Tests whether changes made in textarea updates the json document."""
+
+        json_doc = JsonDocument.objects.create(
+            name="test_json", content=TEST_JSON_CONTENT
+        )
+        self.login()
+        self.open(f"/admin/test_app/jsondocument/{json_doc.pk}/change")
+        toggle_btn = self.find_element(By.CLASS_NAME, TOGGLE_TEXTAREA_BUTTON)
+        toggle_btn.click()
+        textarea = self.find_element(By.CSS_SELECTOR, ".flat-json-textarea textarea")
+        self.assertEqual(
+            textarea.get_attribute("value"),
+            '{"first_key": "first_val", '
+            '"second_key": "second_val", '
+            '"third_key": "third_val"}',
+        )
+        textarea.clear()
+        textarea.send_keys('{"first_key": "first_val", "second_key": "second_val"}')
+        save_btn = self.find_element(By.CSS_SELECTOR, SAVE_BUTTON)
+        save_btn.click()
+        self.assertEqual(
+            JsonDocument.objects.first().content,
+            {
+                "first_key": "first_val",
+                "second_key": "second_val",
+            },
+        )
+
+    def test_textarea_edit_updates_widget(self):
+        """Tests whether the changes made in textarea is visible in widget mode"""
+
+        self.login()
+        self.open("/admin/test_app/jsondocument/add")
+        textarea_toggle_btn = self.find_element(By.CLASS_NAME, TOGGLE_TEXTAREA_BUTTON)
+        textarea_toggle_btn.click()
+        textarea = self.find_element(By.CSS_SELECTOR, ".flat-json-textarea textarea")
+        textarea.clear()
+        textarea.send_keys('{"key": "value"}')
+        textarea_toggle_btn.click()
+        key = self.find_element(By.CLASS_NAME, "flat-json-key").get_attribute("value")
+        val = self.find_element(By.CLASS_NAME, "flat-json-value").get_attribute("value")
+        self.assertEqual((key, val), ("key", "value"))

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -19,9 +19,7 @@ TEST_JSON_CONTENT = {
 }
 
 
-class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
-    """Functional tests for the flat JSON widget in Django admin using Selenium"""
-
+class TestFlatJsonWidgetAdmin(SeleniumTestMixin, StaticLiveServerTestCase):
     def _create_admin(self, username, password):
         User = get_user_model()
         return User.objects.create_superuser(
@@ -30,8 +28,6 @@ class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
             password,
         )
 
-    # Overriding open() and _wait_until_page_ready() so that #main
-    # is used instead of #main-content as CSS selector.
     def open(self, url, html_container="#main", driver=None, timeout=5):
         super().open(url, html_container, driver, timeout)
 
@@ -39,7 +35,6 @@ class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
         super()._wait_until_page_ready(html_container, timeout, driver)
 
     def scroll_and_click(self, element):
-        """Scrolls element into view and clicks it"""
         self.web_driver.execute_script(
             "arguments[0].scrollIntoView({block: 'center', inline: 'nearest'});",
             element,
@@ -47,8 +42,6 @@ class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
         element.click()
 
     def test_add_row(self):
-        """This test checks whether the add-row button works properly."""
-
         self.login()
         self.open(reverse("admin:test_app_jsondocument_add"))
         self.wait_for_presence(By.CLASS_NAME, ADD_ROW_BUTTON)
@@ -71,8 +64,6 @@ class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
         )
 
     def test_remove_row(self):
-        """This test checks whether the remove-row button removes the desired row"""
-
         json_doc = JsonDocument.objects.create(
             name="test_json", content=TEST_JSON_CONTENT
         )
@@ -103,8 +94,6 @@ class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
         )
 
     def test_toggle_textarea(self):
-        """Tests whether the toggle button toggles between widgets and textarea"""
-
         self.login()
         self.open(reverse("admin:test_app_jsondocument_add"))
         self.wait_for_presence(By.CLASS_NAME, TOGGLE_TEXTAREA_BUTTON)
@@ -122,7 +111,7 @@ class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
         self.assertIsNotNone(textarea)
 
     def test_edit_json_from_textarea(self):
-        """Tests whether changes made in textarea updates the json document."""
+        """Changes made in textarea update the JSON document."""
 
         json_doc = JsonDocument.objects.create(
             name="test_json", content=TEST_JSON_CONTENT
@@ -154,7 +143,7 @@ class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
         )
 
     def test_textarea_edit_updates_widget(self):
-        """Tests whether the changes made in textarea is visible in widget mode"""
+        """Changes made to the textarea are visible in widget mode."""
 
         self.login()
         self.open(reverse("admin:test_app_jsondocument_add"))

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -79,6 +79,8 @@ class FrontendTests(SeleniumTestMixin, StaticLiveServerTestCase):
         self.wait_for_presence(By.CLASS_NAME, "flat-json-remove-row")
         remove_buttons = self.find_elements(By.CLASS_NAME, REMOVE_ROW_BUTTON)
         second_row_remove_btn = remove_buttons[1]
+        from time import sleep
+        sleep(0.5)
         self.scroll_and_click(second_row_remove_btn)
         rows = self.find_elements(By.CSS_SELECTOR, ".flat-json-rows .form-row")
         self.assertEqual(


### PR DESCRIPTION
Added frontend tests for the flat JSON widget in Django admin using `openwisp_utils.tests.SeleniumTestMixin`. The following 5 unit tests are included:

- **Add row test**: Simulates adding a row using the “add” button. Verifies that a new row appears and that it is correctly saved to the database after clicking save button.
- **Remove row test:** Creates a sample test json document with 3 rows. Removes the second row and verifies that only 2 rows remain, while the first and third rows remain the same.
- **Toggle text area test:** Verifies that clicking the “toggle textarea” button hides the form rows and add-row button, and displays the raw JSON textarea instead.
- **Editting json from textarea test:** Creates a sample test json document with 3 rows. Switches to textarea mode, removes one row by editing the raw JSON, and verifies that the changes are saved correctly.
- **Widget mode and raw mode sync test:** Modifies JSON in the textarea, toggles back to widget mode without saving, and checks that the changes are visible in the form row of widget mode.

Fixes #02